### PR TITLE
Implement logging and UI micro patches

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ import json
 import logging
 import math
 import os
+import sys
 import tempfile
 import time
 from datetime import datetime, timedelta, timezone
@@ -1352,7 +1353,8 @@ def _run_pipeline(hours: int, bbox: list | None, prefix: str | None) -> None:
         "validation_sparse_fallbacks={validation_sparse_fallbacks} "
         "os_anom_rows={os_anom_rows} wall_ms={wall_ms}"
     ).format(**metrics)
-    print(metrics_line)
+    print(metrics_line, flush=True)
+    sys.stdout.flush()
 
 
 

--- a/scripts/ui_smoke.py
+++ b/scripts/ui_smoke.py
@@ -23,10 +23,31 @@ def _load_latest() -> pd.DataFrame:
 
 
 def main() -> None:
+    app_path = ROOT / "app.py"
+    app_text = app_path.read_text(encoding="utf-8")
+    if "Window:" not in app_text:
+        raise SystemExit("Window header text missing")
     df = _load_latest()
     sub = _filter_window(df, 24)
     _ = _prepare_heatmap(sub)
     _ = _watch_cells(sub, cutoff=0.35, only_mnd=False, top_k=5)
+    risk_path = ROOT / "data" / "enriched" / "daily_grid_risk.csv"
+    if risk_path.exists():
+        distinct = 0
+        try:
+            risk_df = pd.read_csv(risk_path)
+            if "risk_score" in risk_df.columns:
+                risk_series = pd.to_numeric(
+                    risk_df["risk_score"], errors="coerce"
+                ).dropna()
+                distinct = int(risk_series.nunique())
+        except Exception as exc:
+            print(f"daily_grid_risk.csv read failed: {exc}")
+        else:
+            print(
+                "daily_grid_risk distinct risk_score="
+                f"{distinct}"
+            )
     print("ui_smoke passed")
 
 


### PR DESCRIPTION
## Summary
- add optional logging and append support for manage.py subcommands and emit a confirmation when logs are written
- flush the METRICS line immediately and enhance the Streamlit window header plus flat-risk warning
- harden ui_smoke to assert the new window header text and report risk-score distinct counts

## Testing
- `python - <<'PY'
import importlib
for m in ('main','deepseek_enrichment','app'):
    importlib.import_module(m)
    print(m, 'OK')
PY`
- `python ./scripts/ui_smoke.py`
- `python ./manage.py run --hours 1 --log ./logs/tee.log`
- `grep -n 'Window:' app.py`

------
https://chatgpt.com/codex/tasks/task_e_68cf7ccc2024833281ef599d3e31c920